### PR TITLE
issue-52

### DIFF
--- a/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
+++ b/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
@@ -268,7 +268,7 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 				update_post_meta( $order_id, '_alg_wc_full_custom_order_number', $con_order_number );
 				update_post_meta( $order_id, '_alg_wc_custom_order_number_meta_key_updated', 1 );
 			}
-			if ( 10000 > count( $loop_orders->posts ) ) {
+			if ( 5000 > count( $loop_orders->posts ) ) {
 				update_option( 'alg_custom_order_number_no_old_con_without_meta_key', 'yes' );
 			}
 		}
@@ -279,7 +279,7 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 		public function alg_custom_order_number_old_orders_without_meta_key() {
 			$args        = array(
 				'post_type'      => 'shop_order',
-				'posts_per_page' => 10000, // phpcs:ignore
+				'posts_per_page' => 5000, // phpcs:ignore
 				'post_status'    => 'any',
 				'meta_query'     => array( // phpcs:ignore
 					'relation' => 'AND',

--- a/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
+++ b/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
@@ -58,6 +58,10 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 					// To unset the CON meta key at the time of renewal of subscription, so that renewal orders don't have duplicate order numbers.
 					add_filter( 'wcs_renewal_order_meta', array( $this, 'remove_con_metakey_in_wcs_order_meta' ), 10, 3 );
 				}
+				add_action( 'admin_init', array( $this, 'alg_custom_order_number_old_orders_without_meta_key' ) );
+				add_action( 'admin_init', array( $this, 'alg_custom_order_numbers_add_recurring_action_to_add_meta_key' ) );
+				add_action( 'alg_custom_order_numbers_update_meta_key_in_old_con', array( $this, 'alg_custom_order_numbers_update_meta_key_in_old_con_callback' ) );
+				add_action( 'wp_ajax_alg_custom_order_numbers_admin_meta_key_notice_dismiss', array( $this, 'alg_custom_order_numbers_admin_meta_key_notice_dismiss' ) );
 			}
 		}
 
@@ -117,6 +121,24 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 					<?php
 				}
 			}
+			if ( 'yes' === get_option( 'alg_custom_order_number_old_orders_to_update_meta_key', '' ) ) {
+				if ( '' === get_option( 'alg_custom_order_numbers_update_meta_key_in_database', '' ) ) {
+					?>
+					<div class=''>
+						<div class="con-lite-message notice notice-info" style="position: relative;">
+							<p style="margin: 10px 0 10px 10px; font-size: medium;">
+								<?php
+									echo esc_html_e( 'In order to make the previous orders searchable on Orders page where meta key of the custom order number is not present, we need to update the database. Please click the "Update Now" button to do this. The database update process will run in the background.', 'custom-order-numbers-for-woocommerce' );
+								?>
+							</p>
+							<p class="submit" style="margin: -10px 0 10px 10px;">
+								<a class="button-primary button button-large" id="con-lite-update" href="edit.php?post_type=shop_order&action=alg_custom_order_numbers_update_old_con_with_meta_key"><?php esc_html_e( 'Update Now', 'custom-order-numbers-for-woocommerce' ); ?></a>
+							</p>
+						</div>
+					</div>
+					<?php
+				}
+			}
 		}
 
 		/**
@@ -128,10 +150,29 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 		public function alg_custom_order_numbers_add_recurring_action() {
 			if ( isset( $_REQUEST['action'] ) && 'alg_custom_order_numbers_update_old_con_in_database' === $_REQUEST['action'] ) { // phpcs:ignore
 				update_option( 'alg_custom_order_numbers_update_database', 'yes' );
-				$current_time = current_time( 'timestamp' );
+				$current_time = current_time( 'timestamp' ); // phpcs:ignore
 				update_option( 'alg_custom_order_numbers_time_of_update_now', $current_time );
 				if ( function_exists( 'as_next_scheduled_action' ) ) { // Indicates that the AS library is present.
 					as_schedule_recurring_action( time(), 300, 'alg_custom_order_numbers_update_old_custom_order_numbers' );
+				}
+				wp_safe_redirect( admin_url( 'edit.php?post_type=shop_order' ) );
+				exit;
+			}
+		}
+
+		/**
+		 * Function to add a scheduled action when Update now button is clicked in admin notice.AS will run every 5 mins and will run the script to add the meta key of CON in old orders where it is missing.
+		 *
+		 * @version 1.3.0
+		 * @since   1.3.0
+		 */
+		public function alg_custom_order_numbers_add_recurring_action_to_add_meta_key() {
+			if ( isset( $_REQUEST['action'] ) && 'alg_custom_order_numbers_update_old_con_with_meta_key' === $_REQUEST['action'] ) { // phpcs:ignore
+				update_option( 'alg_custom_order_numbers_update_meta_key_in_database', 'yes' );
+				$current_time = current_time( 'timestamp' ); // phpcs:ignore
+				update_option( 'alg_custom_order_numbers_meta_key_time_of_update_now', $current_time );
+				if ( function_exists( 'as_next_scheduled_action' ) ) { // Indicates that the AS library is present.
+					as_schedule_recurring_action( time(), 300, 'alg_custom_order_numbers_update_meta_key_in_old_con' );
 				}
 				wp_safe_redirect( admin_url( 'edit.php?post_type=shop_order' ) );
 				exit;
@@ -197,6 +238,71 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 		}
 
 		/**
+		 * Callback function for the AS to run the script to add the CON meta key for the old orders where it is missing.
+		 */
+		public function alg_custom_order_numbers_update_meta_key_in_old_con_callback() {
+			$loop_orders = $this->alg_custom_order_number_old_orders_without_meta_key();
+			if ( '' === $loop_orders ) {
+				update_option( 'alg_custom_order_number_no_old_con_without_meta_key', 'yes' );
+				return;
+			}
+			foreach ( $loop_orders->posts as $order_ids ) {
+				$order_id              = $order_ids->ID;
+				$order_number_meta     = $order_id;
+				$is_wc_version_below_3 = version_compare( get_option( 'woocommerce_version', null ), '3.0.0', '<' );
+				$order                 = wc_get_order( $order_id );
+				$order_timestamp       = strtotime( ( $is_wc_version_below_3 ? $order->order_date : $order->get_date_created() ) );
+				$time                  = get_option( 'alg_custom_order_numbers_meta_key_time_of_update_now', '' );
+				if ( $order_timestamp > $time ) {
+					return;
+				}
+				$con_order_number = apply_filters(
+					'alg_wc_custom_order_numbers',
+					sprintf( '%s%s', do_shortcode( get_option( 'alg_wc_custom_order_numbers_prefix', '' ) ), $order_number_meta ),
+					'value',
+					array(
+						'order_timestamp'   => $order_timestamp,
+						'order_number_meta' => $order_number_meta,
+					)
+				);
+				update_post_meta( $order_id, '_alg_wc_full_custom_order_number', $con_order_number );
+				update_post_meta( $order_id, '_alg_wc_custom_order_number_meta_key_updated', 1 );
+			}
+			if ( 10000 > count( $loop_orders->posts ) ) {
+				update_option( 'alg_custom_order_number_no_old_con_without_meta_key', 'yes' );
+			}
+		}
+
+		/**
+		 * Function to get the old orders where CON meta key is missing.
+		 */
+		public function alg_custom_order_number_old_orders_without_meta_key() {
+			$args        = array(
+				'post_type'      => 'shop_order',
+				'posts_per_page' => 10000, // phpcs:ignore
+				'post_status'    => 'any',
+				'meta_query'     => array( // phpcs:ignore
+					'relation' => 'AND',
+					array(
+						'key'     => '_alg_wc_custom_order_number',
+						'compare' => 'NOT EXISTS',
+					),
+					array(
+						'key'     => '_alg_wc_custom_order_number_meta_key_updated',
+						'compare' => 'NOT EXISTS',
+					),
+				),
+			);
+			$loop_orders = new WP_Query( $args );
+			if ( ! $loop_orders->have_posts() ) {
+				return '';
+			} else {
+				update_option( 'alg_custom_order_number_old_orders_to_update_meta_key', 'yes' );
+				return $loop_orders;
+			}
+		}
+
+		/**
 		 * Stop AS when there are no old orders left to update the CON meta key.
 		 *
 		 * @version 1.3.0
@@ -205,6 +311,9 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 		public static function alg_custom_order_numbers_stop_recurring_action() {
 			if ( 'yes' === get_option( 'alg_custom_order_numbers_no_old_orders_to_update', '' ) ) {
 				as_unschedule_all_actions( 'alg_custom_order_numbers_update_old_custom_order_numbers' );
+			}
+			if ( 'yes' === get_option( 'alg_custom_order_number_no_old_con_without_meta_key', '' ) ) {
+				as_unschedule_all_actions( 'alg_custom_order_numbers_update_meta_key_in_old_con' );
 			}
 		}
 
@@ -230,6 +339,22 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 					<?php
 				}
 			}
+
+			if ( 'yes' === get_option( 'alg_custom_order_number_no_old_con_without_meta_key', '' ) ) {
+				if ( 'dismissed' !== get_option( 'alg_custom_order_numbers_success_notice_for_meta_key', '' ) ) {
+					?>
+					<div>
+						<div class="con-lite-message con-lite-meta-key-success-message notice notice-success is-dismissible" style="position: relative;">
+							<p>
+								<?php
+									echo esc_html_e( 'Database updated successfully. In addition to new orders henceforth, you can now also search the old orders on Orders page with the custom order numbers.', 'custom-order-numbers-for-woocommerce' );
+								?>
+							</p>
+						</div>
+					</div>
+					<?php
+				}
+			}
 		}
 
 		/**
@@ -241,6 +366,14 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 		public function alg_custom_order_numbers_admin_notice_dismiss() {
 			$admin_choice = isset( $_POST['admin_choice'] ) ? sanitize_text_field( wp_unslash( $_POST['admin_choice'] ) ) : ''; // phpcs:ignore
 			update_option( 'alg_custom_order_numbers_success_notice', $admin_choice );
+		}
+
+		/**
+		 * Function to dismiss the admin notice.
+		 */
+		public function alg_custom_order_numbers_admin_meta_key_notice_dismiss() {
+			$admin_choice = isset( $_POST['alg_admin_choice'] ) ? sanitize_text_field( wp_unslash( $_POST['alg_admin_choice'] ) ) : ''; // phpcs:ignore
+			update_option( 'alg_custom_order_numbers_success_notice_for_meta_key', $admin_choice );
 		}
 
 		/**

--- a/custom-order-numbers-for-woocommerce/includes/js/con-dismiss-notice.js
+++ b/custom-order-numbers-for-woocommerce/includes/js/con-dismiss-notice.js
@@ -14,4 +14,13 @@ jQuery(document).ready(function($) {
 		jQuery.post( con_dismiss_param.ajax_url, data, function() {
 		});
     });
+
+	jQuery( '.con-lite-meta-key-success-message' ).on( 'click', '.notice-dismiss', function() {
+		var data = {
+			alg_admin_choice: 'dismissed',
+			action: 'alg_custom_order_numbers_admin_meta_key_notice_dismiss'
+		};
+		jQuery.post( con_dismiss_param.ajax_url, data, function() {
+		});
+    });
 });


### PR DESCRIPTION
Old orders were not searchable where the meta key was not present. This is fixed now.

Fixes #52

In this fix, we will show the admin notice when the CON meta keys are not present in the old orders, and after updating the database we will add the new meta key in those orders so that they can be searchable on the Orders page.
