### PR TITLE
issue-72

### DIFF
--- a/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
+++ b/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
@@ -734,6 +734,7 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 		 */
 		public function search_by_custom_number( $metakeys ) {
 			$metakeys[] = '_alg_wc_full_custom_order_number';
+			$metakeys[] = '_alg_wc_custom_order_number';
 			return $metakeys;
 		}
 


### PR DESCRIPTION
On the client site, there was a strange behavior of new meta key not present in some of the middle orders, and for the workaround have added the old meta in the array of search fields, so that search can be done by the order ids also.

Fix #72